### PR TITLE
Purge unused css

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,11 @@
 module.exports = {
+  plugins: [],
+  purge: [
+    './src/**/*.html',
+    './src/**/*.js',
+  ],
   theme: {
     extend: {}
   },
   variants: {},
-  plugins: []
 }


### PR DESCRIPTION
Eliminate the following warning:

>Tailwind is not purging unused styles because no template paths have been provided.
>
>If you have manually configured PurgeCSS outside of Tailwind or are deliberately not
removing unused styles, set `purge: false` in your Tailwind config file to silence
this warning.
>[https://tailwindcss.com/docs/controlling-file-size/#removing-unused-css](https://tailwindcss.com/docs/controlling-file-size/#removing-unused-css)